### PR TITLE
Completely Re-Implemented InvokeAsync() 

### DIFF
--- a/Helpers/Extensions.cs
+++ b/Helpers/Extensions.cs
@@ -91,16 +91,12 @@ namespace OpenCollections
 
         private static void HookEventsAsync(this IConcurrentEvent host, IConcurrentEvent subscriber)
         {
-            host.Finished += () => subscriber.InvokeAsync();
-            host.CollectionChanged += () => subscriber.InvokeAsync();
-            host.Started += () => subscriber.InvokeAsync();
+            host.CollectionChangedAsync += subscriber.InvokeAsync;
         }
 
         private static void UnHookEventsAsync(this IConcurrentEvent host, IConcurrentEvent subscriber)
         {
-            host.Finished -= () => subscriber.InvokeAsync();
-            host.CollectionChanged -= () => subscriber.InvokeAsync();
-            host.Started -= () => subscriber.InvokeAsync();
+            host.CollectionChangedAsync -= subscriber.InvokeAsync;
         }
     }
 }

--- a/Interfaces/IConcurrentEvent.cs
+++ b/Interfaces/IConcurrentEvent.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenCollections
@@ -37,7 +38,7 @@ namespace OpenCollections
         /// <see cref="ConcurrentWriter{T}"/>.InvokeAsync() =&gt; <see cref="ConcurrentWriter{T}"/>.WriteLinesAsync()
         /// </para>
         /// </summary>
-        Task InvokeAsync();
+        Task InvokeAsync(CancellationToken token);
 
         /// <summary>
         /// Invoked when the object is finished with its primary function, for example a <see cref="ConcurrentConsumer{T, TResult}"/>.Finished event will invoke when it's finished consuming.
@@ -48,6 +49,11 @@ namespace OpenCollections
         /// Invoked when the collection on this object has changed, this is normally invoked when a consumer consumes an item, or a producer produces an item for exmaple. This is normally invoked the ResultCollection has changed.
         /// </summary>
         event Action CollectionChanged;
+
+        /// <summary>
+        /// Invoked when the collection on this object has changed, this is normally invoked when a consumer consumes an item, or a producer produces an item for exmaple. This is normally invoked the ResultCollection has changed.
+        /// </summary>
+        event Func<CancellationToken, Task> CollectionChangedAsync;
 
         /// <summary>
         /// Invoked when the object is starts its primary function, for example a <see cref="ConcurrentConsumer{T, TResult}"/>.Started event will invoke when it's first started consuming, just before it consumes its first item.

--- a/OpenCollections.Test/ConcurrentProducerTsts.cs
+++ b/OpenCollections.Test/ConcurrentProducerTsts.cs
@@ -92,7 +92,7 @@ namespace OpenCollections.Tests
         {
             string[] expected = CreateTestData();
             var multi = Factory.CreateProducer(expected);
-            multi.InvokeAsync();
+            multi.InvokeAsync(default);
             void ThrowsIfSuccess()
             {
                 multi.Cancel();

--- a/OpenCollections.Test/ConcurrentWriterTests.cs
+++ b/OpenCollections.Test/ConcurrentWriterTests.cs
@@ -385,7 +385,7 @@ namespace OpenCollections.Tests
 
                 using (var writer = Factory.CreateWriter(path, NewQueue()))
                 {
-                    Task.WaitAll(writer.InvokeAsync());
+                    Task.WaitAll(writer.InvokeAsync(default));
                 }
 
                 result = Helpers.VerifyCollection(expected, ReadFileLines(path));

--- a/OpenCollections.Test/ExtensionsTests.cs
+++ b/OpenCollections.Test/ExtensionsTests.cs
@@ -113,7 +113,7 @@ namespace OpenCollections.Tests
 
             consumer.Started += () => { consumerStarted = true; };
 
-            producer.Produce();
+            Task.WaitAll(producer.ProduceAsync());
 
             try
             {

--- a/OpenCollections.Test/ExtensionsTests.cs
+++ b/OpenCollections.Test/ExtensionsTests.cs
@@ -113,7 +113,7 @@ namespace OpenCollections.Tests
 
             consumer.Started += () => { consumerStarted = true; };
 
-            Task.WaitAll(producer.ProduceAsync());
+            producer.Produce();
 
             try
             {

--- a/OpenCollections.Test/MultiConcurrentConsumerTests.cs
+++ b/OpenCollections.Test/MultiConcurrentConsumerTests.cs
@@ -138,7 +138,7 @@ namespace OpenCollections.Tests
         private void DoesntThrowWhenCancelAndNoManagedToken()
         {
             var multi = Factory.CreateMultiConsumer<int, int>();
-            multi.InvokeAsync();
+            multi.InvokeAsync(default);
             void ThrowsIfSuccess()
             {
                 multi.Cancel();

--- a/Producers/ConcurrentProducer.cs
+++ b/Producers/ConcurrentProducer.cs
@@ -25,23 +25,13 @@ namespace OpenCollections
         /// </summary>
         public bool Producing { get; private set; }
 
-        /// <summary>
-        /// Invokes when the producer begins producing items.
-        /// </summary>
-        /// 
         public event Action Started;
 
-        /// <summary>
-        /// Invokes when the producer has finished producing items from the <see cref="IEnumerable"/>
-        /// </summary>
-        /// 
-        public event Action Finished;
-
-        /// <summary>
-        /// Invokes every time the <see cref="ResultCollection"/> has items added to it.
-        /// </summary>
         public event Action CollectionChanged;
 
+        public event Func<CancellationToken, Task> CollectionChangedAsync;
+
+        public event Action Finished;
         /// <summary>
         /// The list where items are temporaily stored while they are waiting to be added to the <see cref="ResultCollection"/>
         /// </summary>
@@ -104,6 +94,7 @@ namespace OpenCollections
                     }
 
                     CollectionChanged?.Invoke();
+                    CollectionChangedAsync?.Invoke(token);
                 }
             }
 
@@ -164,7 +155,10 @@ namespace OpenCollections
 
         public void Invoke() => Produce();
 
-        public async Task InvokeAsync() => await ProduceAsync().ConfigureAwait(false);
+        public async Task InvokeAsync(CancellationToken token)
+        {
+            await ProduceAsync(token).ConfigureAwait(false);
+        }
 
         ~ConcurrentProducer()
         {


### PR DESCRIPTION
Completely Re-Implemented InvokeAsync() to use Cancellation Tokens in order to prevent mis-subscriptions to events, and furthermore to avoid ghost threads